### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,4 @@ git clone https://github.com/JoeBanks13/webhook-discord.git
 
 MIT
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/k8VxqFJqofuweakvbrKSfT6B/JoeBanks13/webhook-discord'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/k8VxqFJqofuweakvbrKSfT6B/JoeBanks13/webhook-discord.svg' />
-</a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8